### PR TITLE
Pr flag customization

### DIFF
--- a/assets/lib/commands/out.rb
+++ b/assets/lib/commands/out.rb
@@ -54,7 +54,9 @@ module Commands
           atc_url: atc_url,
           sha: sha,
           repo: repo,
-          context: whitelist(context: context)
+          context: whitelist(context: context),
+          description: params.description,
+          title: params.title
         ).create!
       end
 

--- a/assets/lib/status.rb
+++ b/assets/lib/status.rb
@@ -1,12 +1,14 @@
 require 'octokit'
 
 class Status
-  def initialize(state:, atc_url:, sha:, repo:, context: 'concourse-ci')
+  def initialize(state:, atc_url:, sha:, repo:, title:, description:, context: 'concourse-ci')
     @atc_url = atc_url
     @context = context
     @repo    = repo
     @sha     = sha
     @state   = state
+    @title   = title.nil? ? 'concourse-ci' : title
+    @description = description.nil? ? "Concourse CI build #{@state}" : description
   end
 
   def create!
@@ -14,8 +16,8 @@ class Status
       @repo.name,
       @sha,
       @state,
-      context: "concourse-ci/#{@context}",
-      description: "Concourse CI build #{@state}",
+      context: "#{@title}/#{@context}",
+      description: @description,
       target_url: target_url
     )
   end

--- a/spec/commands/out_spec.rb
+++ b/spec/commands/out_spec.rb
@@ -221,8 +221,16 @@ describe Commands::Out do
           end
         end
 
+        context 'with a custom context for the status, custom title, and custom description' do
+          it 'sets the context' do
+            stub_status_post.with(body: hash_including('context' => 'my-title/my-custom-context', 'description' => 'My custom description.'))
+
+            put('params' => { 'status' => 'success', 'path' => 'resource', 'context' => 'my-custom-context', 'title' => 'my-title', 'description' => 'My custom description.' }, 'source' => { 'repo' => 'jtarchie/test' })
+          end
+        end
+
         it 'sets the a default context on the status' do
-          stub_status_post.with(body: hash_including('context' => 'concourse-ci/status'))
+          stub_status_post.with(body: hash_including('context' => 'concourse-ci/status', 'description' => 'Concourse CI build success'))
 
           put('params' => { 'status' => 'success', 'path' => 'resource' }, 'source' => { 'repo' => 'jtarchie/test' })
         end


### PR DESCRIPTION
* Allowing to set the property `title` to replace "concourse-ci"
* Allowing to set the property `description` to replace "Concourse CI build success."